### PR TITLE
Update Terraform Sample Policies

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,188 @@
+name: 'Terraform Plan/Apply'
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '.github/workflows/terraform.yaml'
+    - 'ConditionalAccessSamplePoliciesTerraform/**'
+    
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'ConditionalAccessSamplePoliciesTerraform/**'
+
+
+#Special permissions required for OIDC authentication
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+#These environment variables are used by the terraform azure provider to setup OIDC authenticate. 
+env:
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
+  
+
+jobs:
+  terraform-plan:
+    name: 'Terraform Plan'
+    runs-on: ubuntu-latest
+    env:
+      #this is needed since we are running terraform with read-only permissions
+      ARM_SKIP_PROVIDER_REGISTRATION: true
+    outputs:
+      tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the latest version of the Terraform CLI
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_wrapper: false
+
+    # Change Directory to EntraID Directory and Print Working Directory
+    - name: Change Directory
+      run: cd EntraID && pwd && ls -la
+      
+
+
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc from the EntraID Directory
+    
+    - name: Terraform Init
+      run: cd EntraID && terraform init
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    # Will fail the build if not
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    # Az CLI Login with Federated Credentials
+    - name: 'Az CLI login with Federated Credentials'
+      uses: azure/login@v1
+      with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+    # Generates an execution plan for Terraform
+    # An exit code of 0 indicated no changes, 1 a terraform failure, 2 there are pending changes.
+    - name: Terraform Plan
+      id: tf-plan
+      run: |
+        export exitcode=0
+        cd EntraID && terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+
+        echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+        
+        if [ $exitcode -eq 1 ]; then
+          echo Terraform Plan Failed!
+          exit 1
+        else 
+          exit 0
+        fi
+
+
+    # Save plan to artifacts  
+    - name: Publish Terraform Plan
+      uses: actions/upload-artifact@v3
+      with:
+        name: tfplan
+        path: EntraID/tfplan
+        
+    # Create string output of Terraform Plan
+    - name: Create String Output
+      id: tf-plan-string
+      run: |
+        TERRAFORM_PLAN=$( cd EntraID && terraform show -no-color tfplan)
+        
+        delimiter="$(openssl rand -hex 8)"
+        echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
+        echo "## Terraform Plan Output" >> $GITHUB_OUTPUT
+        echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
+        echo "" >> $GITHUB_OUTPUT
+        echo '```terraform' >> $GITHUB_OUTPUT
+        echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+        echo '```' >> $GITHUB_OUTPUT
+        echo "</details>" >> $GITHUB_OUTPUT
+        echo "${delimiter}" >> $GITHUB_OUTPUT
+        
+    # Publish Terraform Plan as task summary
+    - name: Publish Terraform Plan to Task Summary
+      env:
+        SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
+      run: |
+        echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+      
+    If this is a PR post the changes
+    - name: Push Terraform Output to PR
+      if: github.ref != 'refs/heads/master'
+      uses: actions/github-script@v6
+      env:
+        SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
+      with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `${process.env.SUMMARY}`;
+            github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+            })
+                
+  terraform-apply:
+    name: 'Terraform Apply'
+    env:
+      #this is needed since we are running terraform with read-only permissions
+      ARM_SKIP_PROVIDER_REGISTRATION: true
+      ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
+    
+    if: github.ref == 'refs/heads/master' && needs.terraform-plan.outputs.tfplanExitCode == 2
+    runs-on: ubuntu-latest
+    needs: [terraform-plan]
+    
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+    
+    # Az CLI Login with Federated Credentials
+    - name: 'Az CLI login with Federated Credentials'
+      uses: azure/login@v1
+      with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+    # Change Directory to HF Directory and Print Working Directory
+    - name: Change Directory
+      run: cd EntraID && pwd && ls -la
+      
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: cd EntraID && terraform init
+
+    # Download saved plan from artifacts  q
+    - name: Download Terraform Plan
+      uses: actions/download-artifact@v3
+      with:
+        name: tfplan
+
+    # Terraform Apply
+    - name: Terraform Apply
+      run: cd EntraID && terraform apply -auto-approve ../tfplan
+

--- a/ConditionalAccessSamplePoliciesTerraform/azuread_conditional_access_policy.tf
+++ b/ConditionalAccessSamplePoliciesTerraform/azuread_conditional_access_policy.tf
@@ -1,0 +1,586 @@
+
+resource "azuread_conditional_access_policy" "CA200-Internals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ" {
+  display_name = "CA200-Internals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+      excluded_applications = [data.azuread_service_principal.intune.client_id]
+    }
+    platforms {
+      included_platforms = ["all"]
+
+    }
+   
+    
+    
+
+    users {
+      included_groups = [ azuread_group.CA-Persona-Groups["Internals"].id ]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.BaseProtection"].id]
+      
+    }
+    client_app_types = ["all"]
+
+
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["compliantDevice", "domainJoinedDevice"]
+  }
+
+
+}
+
+
+
+resource "azuread_conditional_access_policy" "CA202-Internals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk" {
+  display_name = "CA202-Internals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+
+    client_app_types = ["all"]
+    user_risk_levels = ["high"]
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.IdentityProtection"].id]
+    }
+
+
+
+
+
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["passwordChange", "mfa"]
+  }
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA203-Internals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk" {
+  display_name = "CA203-Internals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["all"]
+    sign_in_risk_levels = ["high"]
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.IdentityProtection"].id]
+    }
+
+
+
+
+
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["mfa"]
+  }
+
+  session_controls {
+    sign_in_frequency_interval = "everyTime"
+  }
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA204-Internals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth" {
+  display_name = "CA204-Internals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["exchangeActiveSync", "other"]
+    sign_in_risk_levels = ["high"]
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.IdentityProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["block"]
+  }
+
+}
+
+
+# Internals App and Data Protection
+
+resource "azuread_conditional_access_policy" "CA205-Internals-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA" {
+  display_name = "CA205-Internals-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = [data.azuread_service_principal.intune.client_id]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["all"]
+  
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.AppProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["mfa"]
+  }
+
+  session_controls {
+    sign_in_frequency_interval = "everyTime"
+  }
+
+}
+
+resource "azuread_conditional_access_policy" "CA206-Internals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP" {
+  display_name = "CA206-Internals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["Office365"]
+      excluded_applications = [data.azuread_service_principal.intune.client_id]
+
+    }
+    platforms {
+      included_platforms = ["iOS", "android"]
+    }
+    client_app_types    = ["all"]
+   
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Internals.DataProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["approvedApplication", "compliantApplication"]
+  }
+
+
+
+}
+
+
+resource "azuread_conditional_access_policy" "CA207-Internals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms" {
+  display_name = "CA207-Internals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+
+    }
+    platforms {
+      included_platforms = ["all"]
+      excluded_platforms = ["iOS", "windowsPhone", "macOS", "android", "windows"]
+    }
+    client_app_types = ["all"]
+
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id,  azuread_group.CA-Persona-Groups-Exclusions["Internals.AttackSurfaceReduction"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+}
+
+
+## Externals Policies (CA300-399)
+
+## The Externals are users in AD synced to Azure AD who are not employees, like a consultant. (A consultant may (also) be a guest account instead of an AD account). 
+
+# Externals Base Protection
+
+
+resource "azuread_conditional_access_policy" "CA300-Externals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ" {
+  display_name = "CA300-Externals-BaseProtection-AllApps-AnyPlatform-CompliantorAADHJ"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+      excluded_applications = [data.azuread_service_principal.intune.client_id]
+    }
+    platforms {
+      included_platforms = ["all"]
+
+    }
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.BaseProtection"].id]
+    }
+    client_app_types = ["all"]
+
+
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["compliantDevice", "domainJoinedDevice"]
+  }
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA301-Externals-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration" {
+
+  display_name = "CA301-Externals-IdentityProtection-AllApps-AnyPlatform-CombinedRegistration"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_user_actions = ["urn:user:registersecurityinfo"]
+    }
+    platforms {
+      included_platforms = ["all"]
+
+    }
+
+    locations {
+      included_locations = ["all"]
+    }
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.IdentityProtection"].id]
+    }
+    client_app_types = ["all"]
+
+
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["compliantDevice", "domainJoinedDevice"]
+  }
+}
+
+resource "azuread_conditional_access_policy" "CA302-Externals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk" {
+  display_name = "CA302-Externals-IdentityProtection-AllApps-AnyPlatform-MFAandPWDforHighUserRisk"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+
+    client_app_types = ["all"]
+    user_risk_levels = ["high"]
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.IdentityProtection"].id]
+    }
+
+
+
+
+
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["passwordChange", "mfa"]
+  }
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA303-Externals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk" {
+  display_name = "CA303-Externals-IdentityProtection-AllApps-AnyPlatform-MFAforHighSignInRisk"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["all"]
+    sign_in_risk_levels = ["high"]
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.IdentityProtection"].id]
+    }
+
+
+
+
+
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["mfa"]
+  }
+
+  session_controls {
+    sign_in_frequency_interval = "everyTime"
+  }
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA304-Externals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth" {
+  display_name = "CA304-Externals-IdentityProtection-AllApps-AnyPlatform-BlockLegacyAuth"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["exchangeActiveSync", "other"]
+   
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Internals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.IdentityProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["block"]
+  }
+
+}
+
+
+## Externals App and Data Protection
+
+
+resource "azuread_conditional_access_policy" "CA305-Externals-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA" {
+  display_name = "CA305-Externals-AppProtection-MicrosoftIntuneEnrollment-AnyPlatform-MFA"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = [data.azuread_service_principal.intune.client_id]
+
+    }
+    platforms {
+      included_platforms = ["all"]
+    }
+    client_app_types    = ["all"]
+    
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.AppProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "AND"
+    built_in_controls = ["mfa"]
+  }
+
+  session_controls {
+    sign_in_frequency_interval = "everyTime"
+  }
+
+}
+
+
+
+
+resource "azuread_conditional_access_policy" "CA306-Externals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP" {
+  display_name = "CA306-Externals-DataandAppProtection-AllApps-iOSorAndroid-ClientAppORAPP"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["Office365"]
+      excluded_applications = [data.azuread_service_principal.intune.client_id]
+
+    }
+    platforms {
+      included_platforms = ["iOS", "android"]
+    }
+    client_app_types    = ["all"]
+ 
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id, azuread_group.CA-Persona-Groups-Exclusions["Externals.DataProtection"].id]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["approvedApplication", "compliantApplication"]
+  }
+
+
+
+}
+
+resource "azuread_conditional_access_policy" "CA307-Externals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms" {
+  display_name = "CA307-Externals-AttackSurfaceReduction-AllApps-AnyPlatform-BlockUnknownPlatforms"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+
+
+    }
+    platforms {
+      included_platforms = ["all"]
+      excluded_platforms = ["iOS", "windowsPhone", "macOS", "android", "windows"]
+    }
+    client_app_types = ["all"]
+
+
+
+    users {
+      included_groups = [azuread_group.CA-Persona-Groups["Externals"].id]
+      excluded_groups = [azuread_group.breakglass.id,  azuread_group.CA-Persona-Groups-Exclusions["Externals.AttackSurfaceReduction"].id ]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+}
+
+
+## Workload Identity Protection Policies (CA900-CA999)
+
+# WorkloadIdentities Base Protection
+
+resource "azuread_conditional_access_policy" "CA900-WorkloadIdentities-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations" {
+  display_name = "CA900-WorkloadIdentities-BaseProtection-AllApps-AnyPlatform-BlockUntrustedLocations"
+  state        = "enabledForReportingButNotEnforced"
+  conditions {
+    applications {
+      included_applications = ["All"]
+    }
+     client_applications {
+      included_service_principals = ["ServicePrincipalsInMyTenant"] 
+    }
+    client_app_types = ["all"]
+    locations {
+      included_locations = ["all"]
+      excluded_locations = [azuread_named_location.AzureVnet-ip.id]
+    }
+    users {
+      included_users = ["None"]
+    }    
+  }
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+}
+
+### Global Policies (CA001-CA099)
+
+# Global Base Protection Policies
+
+resource "azuread_conditional_access_policy" "CA001-Global-BaseProtection-AllApps-AnyPlatform-BlockNonPersonas" {
+  display_name = "CA001-Global-BaseProtection-AllApps-AnyPlatform-BlockNonPersonas"
+  state        = "enabledForReportingButNotEnforced"
+
+  conditions {
+    applications {
+      included_applications = ["All"]
+      
+    }
+    platforms {
+      included_platforms = ["all"]
+
+    }
+
+
+    users {
+      included_groups = ["All"]
+      excluded_groups = [azuread_group.breakglass.id,azuread_group.CA-Persona-Groups["Admins"].id, azuread_group.CA-Persona-Groups["WorkloadIdentities"].id,azuread_group.CA-Persona-Groups["Internals"].id, azuread_group.CA-Persona-Groups["Externals"].id,azuread_group.CA-Persona-Groups["Guests"].id,azuread_group.CA-Persona-Groups["GuestAdmins"].id,azuread_group.CA-Persona-Groups["CorpServiceAccounts"].id,azuread_group.CA-Persona-Groups["Developers"].id]
+    }
+    client_app_types = ["all"]
+
+
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+
+}
+
+
+

--- a/ConditionalAccessSamplePoliciesTerraform/azuread_group.tf
+++ b/ConditionalAccessSamplePoliciesTerraform/azuread_group.tf
@@ -1,0 +1,97 @@
+data "azuread_client_config" "current" {}
+
+# Create a Local COnfig and array variables for Local Group Names
+locals {
+  persona_types = [
+    "Internals",
+    "Developers",
+    "Externals",
+    "Guests",
+    "GuestAdmins",
+    "CorpServiceAccounts",
+    "Admins",
+    "WorkloadIdentities",
+  ]
+  policy_types = [
+    "BaseProtection",
+    "AppProtection",
+    "IdentityProtection",
+    "DataProtection",
+    "AttackSurfaceReduction",
+  ]
+  ring_types = [
+    "Ring0",
+    "Ring1",
+    "Ring2",
+    "Ring3",
+  ]
+  
+
+  # Nested loop over both lists, and flatten the result.
+  persona_type_policy_type = distinct(flatten([
+    for persona_type in local.persona_types : [
+      for policy_type in local.policy_types : {
+        persona_type = persona_type
+        policy_type  = policy_type
+      }
+    ]
+  ]))
+
+  persona_type_ring_type = distinct(flatten([
+    for persona_type in local.persona_types : [
+      for ring_type in local.ring_types : {
+        persona_type = persona_type
+        ring_type  = ring_type
+      }
+    ]
+  ]))
+
+}
+
+
+
+resource "azuread_group" "CA-Persona-Rings" {
+  # We need a map to use for_each, so we convert our list into a map by adding a unique key:
+   for_each      = { for entry in local.persona_type_ring_type: "${entry.persona_type}.${entry.ring_type}" => entry }
+  display_name  = "CA-Persona-${each.value.persona_type}-${each.value.ring_type}"
+  security_enabled = true
+  description = "Manually managed by Conditional Access administrators"
+
+}
+
+resource "azuread_group" "CA-Persona-Groups" {
+  # We need a map to use for_each, so we convert our list into a map by adding a unique key:
+  for_each      = toset(local.persona_types)
+  display_name  = "CA-Persona-${each.value}"
+  security_enabled = true
+  description = "Manually managed by Conditional Access administrators"
+  # if each.value == "Internals" {}
+  types    =  ["DynamicMembership"] 
+
+  dynamic_membership {
+    enabled = true
+    rule = each.value == "Internals" ? "user.employeeid -match \"\\d{5}$\"" : each.value == "Externals" ? "user.userPrincipalName -contains \"ext\"" : each.value == "Guests" ? "user.userType  -contains \"Guest\"" : each.value == "CorpServiceAccounts" ? "user.userPrincipalName -contains \"serviceAccounts\"" : each.value == "Admins" ? "user.userPrincipalName -contains \"admin\"" : each.value == "GuestAdmins" ? "user.userType  -contains \"Guest\" -and user.userPrincipalName -contains \"admins\" "   : "user.department -match \"${each.value}\""
+    
+  }
+
+}
+
+
+resource "azuread_group" "CA-Persona-Groups-Exclusions" {
+  # We need a map to use for_each, so we convert our list into a map by adding a unique key:
+  for_each      = { for entry in local.persona_type_policy_type: "${entry.persona_type}.${entry.policy_type}" => entry }
+  display_name  = "CA-Persona-${each.value.persona_type}-${each.value.policy_type}-exclusions"
+  security_enabled = true
+  description = "Manually managed by Conditional Access administrators"
+
+}
+
+
+
+resource "azuread_group" "breakglass" {
+  display_name     = "CA-Breakglass"
+  
+  security_enabled = true
+
+
+}

--- a/ConditionalAccessSamplePoliciesTerraform/azuread_named_location.tf
+++ b/ConditionalAccessSamplePoliciesTerraform/azuread_named_location.tf
@@ -1,0 +1,22 @@
+
+resource "azuread_named_location" "AzureVnet-ip" {
+  display_name = "AzureVnet-ip IP Named Location"
+  ip {
+    ip_ranges = [
+      "1.1.1.1/32",
+      "2.2.2.2/32",
+    ]
+    trusted = true
+  }
+}
+
+resource "azuread_named_location" "TrustedLocation" {
+  display_name = "Trusted Country"
+  country {
+    countries_and_regions = [
+      "GB",
+      "US",
+    ]
+    include_unknown_countries_and_regions = false
+  }
+}

--- a/ConditionalAccessSamplePoliciesTerraform/data.tf
+++ b/ConditionalAccessSamplePoliciesTerraform/data.tf
@@ -1,0 +1,4 @@
+
+data "azuread_service_principal" "intune" {
+  client_id = "d4ebce55-015a-49b5-a083-c84d1797ae8c"
+}

--- a/ConditionalAccessSamplePoliciesTerraform/provider.tf
+++ b/ConditionalAccessSamplePoliciesTerraform/provider.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "=2.45.0"
+    }
+  }
+
+  /*backend "azurerm" {
+    storage_account_name = "iamstgsa"
+    container_name       = "tfstate"
+    key                  = "terraform.tfstate"
+
+    # rather than defining this inline, the Access Key can also be sourced
+    # from an Environment Variable - more information is available below.
+
+  }*/
+
+
+}
+# Configure the Microsoft Azure Provider
+provider "azuread" {
+  use_oidc = true
+
+
+}


### PR DESCRIPTION
I have added a sample terraform code to create the Conditional Access Policy.
And a Sample Github Action workflow to automatically deploy the code in any tenant.




This Terraform Code creates the Persona Groups based on the following Personas.

```
persona_types = [
    "Internals",
    "Developers",
    "Externals",
    "Guests",
    "GuestAdmins",
    "CorpServiceAccounts",
    "Admins",
    "WorkloadIdentities",
  ]

```

We also create necessary Exclusion Groups for policy-specific Exclusions.

```
 policy_types = [
    "BaseProtection",
    "AppProtection",
    "IdentityProtection",
    "DataProtection",
    "AttackSurfaceReduction",
  ]
  ring_types = [
    "Ring0",
    "Ring1",
    "Ring2",
    "Ring3",
  ]

```

We will create the Named Locations (please modify them as per your tenant's requirements).